### PR TITLE
Fix main.dart and add simple home screen

### DIFF
--- a/lib/features/forage/forage_screen.dart
+++ b/lib/features/forage/forage_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ForageScreen extends StatelessWidget {
+  const ForageScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Forage')),
+      body: const Center(child: Text('Écran Forage')),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Accueil')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ElevatedButton(
+            onPressed: () => Navigator.pushNamed(context, '/grid'),
+            child: const Text('Quadrillages'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => Navigator.pushNamed(context, '/forage'),
+            child: const Text('Forage'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => Navigator.pushNamed(context, '/ventesAchats'),
+            child: const Text('Ventes/Achats d\'eau'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => Navigator.pushNamed(context, '/plomberie'),
+            child: const Text('Plomberie'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -22,7 +22,7 @@ class HomeScreen extends StatelessWidget {
           const SizedBox(height: 8),
           ElevatedButton(
             onPressed: () => Navigator.pushNamed(context, '/ventesAchats'),
-            child: const Text('Ventes/Achats d\'eau'),
+            child: const Text("Ventes/Achats d'eau"),
           ),
           const SizedBox(height: 8),
           ElevatedButton(

--- a/lib/features/plomberie/plomberie_screen.dart
+++ b/lib/features/plomberie/plomberie_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class PlomberieScreen extends StatelessWidget {
+  const PlomberieScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Plomberie')),
+      body: const Center(child: Text('Écran Plomberie')),
+    );
+  }
+}

--- a/lib/features/ventes_achats/ventes_achats_screen.dart
+++ b/lib/features/ventes_achats/ventes_achats_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class VentesAchatsScreen extends StatelessWidget {
+  const VentesAchatsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ventes/Achats d\'eau')),
+      body: const Center(child: Text('Écran Ventes/Achats d\'eau')),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'core/constants.dart';
+import 'features/home/home_screen.dart';
+import 'features/grid_view/grid_screen.dart';
+import 'features/forage/forage_screen.dart';
+import 'features/ventes_achats/ventes_achats_screen.dart';
+import 'features/plomberie/plomberie_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,103 +13,20 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'LMF',
+      title: appName,
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: const Scaffold
-	body: center(child: text('Bienvenue sur LMF mobile')),
-      ),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      debugShowCheckedModeBanner: false,
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const HomeScreen(),
+        '/grid': (context) => GridScreen(),
+        '/forage': (context) => const ForageScreen(),
+        '/ventesAchats': (context) => const VentesAchatsScreen(),
+        '/plomberie': (context) => const PlomberieScreen(),
+      },
     );
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,7 +6,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
     expect(find.text('Quadrillages'), findsOneWidget);
     expect(find.text('Forage'), findsOneWidget);
-    expect(find.text('Ventes/Achats d\'eau'), findsOneWidget);
+    expect(find.text("Ventes/Achats d'eau"), findsOneWidget);
     expect(find.text('Plomberie'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:lmf/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Home page shows menu buttons', (tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Quadrillages'), findsOneWidget);
+    expect(find.text('Forage'), findsOneWidget);
+    expect(find.text('Ventes/Achats d\'eau'), findsOneWidget);
+    expect(find.text('Plomberie'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- create placeholder Forage, Ventes/Achats and Plomberie pages
- build a menu on HomeScreen with navigation buttons
- configure MaterialApp with named routes for these pages
- update widget test for the new menu

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570965a3c083338d4e54f2047c8788